### PR TITLE
Prep for Status Indicators

### DIFF
--- a/client/src/components/SendMessageForm.js
+++ b/client/src/components/SendMessageForm.js
@@ -4,7 +4,7 @@ function SendMessageForm({ sessionId }) {
   const [msgSubject, setMsgSubject] = useState(localStorage.getItem('msgSubject') || "Class Cancelled");
   const [msgValue, setMsgValue] = useState(localStorage.getItem('msgValue') || "THIS IS A TEST!");
   const [isMessageSent, setIsMessageSent] = useState(localStorage.getItem('isMessageSent') === 'true');
-  const [dateSent, setDateSent] = useState('');
+  const [dateSent, setDateSent] = useState(localStorage.getItem('dateSent') || '');
 
   useEffect(() => {
     localStorage.setItem('msgSubject', msgSubject);
@@ -22,6 +22,7 @@ function SendMessageForm({ sessionId }) {
   function ClearFields() {
     setMsgValue("");
     setMsgSubject("");
+    setDateSent("");
     localStorage.removeItem('msgSubject');
     localStorage.removeItem('msgValue');
     localStorage.removeItem('dateSent');
@@ -31,7 +32,7 @@ function SendMessageForm({ sessionId }) {
     const requestOptions = {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ subject: msgSubject, message: msgValue, coachId: sessionId })
+      body: JSON.stringify({ subject: msgSubject, message: msgValue, sessionId: sessionId })
     };
     fetch('/sendmessage', requestOptions)
       .then(res => {

--- a/client/src/pages/classList.js
+++ b/client/src/pages/classList.js
@@ -12,10 +12,9 @@ function ClassList() {
   const navigate = useNavigate();
 
   const { state } = useLocation();
-  const [name, setName] = useState(state?.name || JSON.parse(localStorage.getItem('name')));
+  const [name] = useState(state?.name || JSON.parse(localStorage.getItem('name')));
   const [session, setSession] = useState([{}]);
   const [test, setTest] = useState('');
-
 
   useEffect(() => {
     const dataFetch = async (id) => {

--- a/server/api/salesforce.js
+++ b/server/api/salesforce.js
@@ -125,6 +125,14 @@ function coachSessions(id, res) {
     });
 }
 
+// conn.query("SELECT FIELDS(ALL) FROM Session_Registration__c WHERE Name = 'SR-1494829' LIMIT 1", function(err, result) {
+//   if (err) { return console.error(err); }
+//   for (var record of result.records) {
+//     console.log(record);
+//   }
+// });
+
+
 function sessionNumbers(id, res, msg) {
   conn.sobject("Session_Registration__c")
     .select(`Id, Contact__r.Name, Contact__r.Emergency_Contact_Number__c, Contact__r.Contact_Type__c`)

--- a/server/api/salesforce.js
+++ b/server/api/salesforce.js
@@ -125,14 +125,6 @@ function coachSessions(id, res) {
     });
 }
 
-// conn.query("SELECT FIELDS(ALL) FROM Session_Registration__c WHERE Name = 'SR-1494829' LIMIT 1", function(err, result) {
-//   if (err) { return console.error(err); }
-//   for (var record of result.records) {
-//     console.log(record);
-//   }
-// });
-
-
 function sessionNumbers(id, res, msg) {
   conn.sobject("Session_Registration__c")
     .select(`Id, Contact__r.Name, Contact__r.Emergency_Contact_Number__c, Contact__r.Contact_Type__c`)

--- a/server/index.js
+++ b/server/index.js
@@ -66,13 +66,13 @@ app.post("/sendmessage", (req, res) => {
   const body = req.body;
   const subject = body.subject;
   const msg = body.message;
-  const coachId = body.coachId;
+  const sessionId = body.sessionId;
 
-  salesforce.sessionNumbers(coachId, knock.sendSMS, msg);
-  salesforce.sessionEmails(coachId, knock.sendEmail, msg, subject)
+  // salesforce.sessionNumbers(sessionId, knock.sendSMS, msg);
+  // salesforce.sessionEmails(sessionId, knock.sendEmail, msg, subject)
   
-  salesforce.coachNumbers(coachId, knock.sendSMS, msg);
-  salesforce.coachEmails(coachId, knock.sendEmail, msg, subject)
+  // salesforce.coachNumbers(sessionId, knock.sendSMS, msg);
+  // salesforce.coachEmails(sessionId, knock.sendEmail, msg, subject)
 
   res.status(200).send('Status: OK')
 })

--- a/server/index.js
+++ b/server/index.js
@@ -68,11 +68,11 @@ app.post("/sendmessage", (req, res) => {
   const msg = body.message;
   const sessionId = body.sessionId;
 
-  // salesforce.sessionNumbers(sessionId, knock.sendSMS, msg);
-  // salesforce.sessionEmails(sessionId, knock.sendEmail, msg, subject)
+  salesforce.sessionNumbers(sessionId, knock.sendSMS, msg);
+  salesforce.sessionEmails(sessionId, knock.sendEmail, msg, subject)
   
-  // salesforce.coachNumbers(sessionId, knock.sendSMS, msg);
-  // salesforce.coachEmails(sessionId, knock.sendEmail, msg, subject)
+  salesforce.coachNumbers(sessionId, knock.sendSMS, msg);
+  salesforce.coachEmails(sessionId, knock.sendEmail, msg, subject)
 
   res.status(200).send('Status: OK')
 })


### PR DESCRIPTION
DateSent now persists after refresh, renamed coachID to sessionId for readability. Coach Name now persists between page navigations.

On Knock, Mailersend's template has been changed to include the link that forwards you to the confirmation page. Twilio's template has been changed to include a "STOP" feature.