### PR TITLE
Only push sessions with more than 1 participant

### DIFF
--- a/server/api/salesforce.js
+++ b/server/api/salesforce.js
@@ -113,15 +113,28 @@ function coachSessions(id, res) {
       if (err) { return console.error(err); }
       var sessions = [];
       for (var record of records) {
-        sessions.push({
-          id: record.Listing_Session__c,
-          coach_assignment_name: record.Name,
-          start_date: record.Session_Start_Date__c,
-          end_date: record.Session_End_Date__c,
-          session_name: record.Listing_Session__r.Name
-        });
+        conn.sobject("Listing_Session__c")
+          .select("Id, Total_Registrations__c")
+          .where({
+            Id: record.Listing_Session__c
+          })
+          .execute(function (err, listingRecords) {
+            if (err) { return console.error(err); }
+            
+            listingRecords.forEach((listingRecord) => {
+              if (listingRecord.Total_Registrations__c > 0) {
+                sessions.push({
+                  id: record.Listing_Session__c,
+                  coach_assignment_name: record.Name,
+                  start_date: record.Session_Start_Date__c,
+                  end_date: record.Session_End_Date__c,
+                  session_name: record.Listing_Session__r.Name
+                });
+              }
+            });
+            res.send(sessions);
+          });
       }
-      res.send(sessions);
     });
 }
 


### PR DESCRIPTION
## Related Issues
- Resolves #154 

## Changes
- Uses Listing_Session__c.Total_Registrations__c to filter
- If this field is greater than 0, push the session (AKA if there is at least one registration)